### PR TITLE
Use HTTPS instead of SSH for GitHub repositories

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "pulp-tools"]
 	path = pulp-tools
-	url = git@github.com:pulp-platform/pulp-tools.git
+	url = https://github.com/pulp-platform/pulp-tools.git

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Starting from a fresh Ubuntu 16.04 distribution, here are the commands to be exe
 
 Have a look at the dependencies documentation to see how to build them.
 
-You can have a look here for the toolchain: git@github.com:pulp-platform/pulp-riscv-gnu-toolchain.git
+You can have a look here for the toolchain: https://github.com/pulp-platform/pulp-riscv-gnu-toolchain.git
 
 
 ### Dependencies setup
@@ -53,7 +53,7 @@ environment variable must point to the folder where the platform was installed (
 
 First get the sources of the SDK top module:
 
-    $ git clone git@github.com:pulp-platform/pulp-sdk.git -b <sdb branch or tag>
+    $ git clone https://github.com/pulp-platform/pulp-sdk.git -b <sdb branch or tag>
 
 
 Take the *master* branch of the SDK if you want a stable branch with the latest features. The branch *integration* can be taken to get more recent features but may not be fully stable.
@@ -114,7 +114,7 @@ After these steps, the SDK is ready to be used, you can have a look at section *
 
 For a quick hello test, you can get some examples here:
 
-    $ git clone git@github.com:pulp-platform/pulp-rt-examples.git
+    $ git clone https://github.com/pulp-platform/pulp-rt-examples.git
 
 Then you can go to the folder *pulp-rt-examples/hello* and execute:
 
@@ -137,7 +137,7 @@ All the SDK dependencies can be downloaded if they are compatible with the Linux
 
 For that first get the top SDK module, after you have configured your ssh key in gitlab:
 
-    $ git clone git@github.com:pulp-platform/pulp-sdk.git -b <sdb branch or tag>
+    $ git clone https://github.com/pulp-platform/pulp-sdk.git -b <sdb branch or tag>
 
 Take the *master* branch of the SDK if you want the latest features. However this branch may not be fully stable. The *release* branch can be retrieved to get the latest stable release. Otherwise any other branch or tag. There is always a tag whose name is the one of the SDK tag which is released.
 
@@ -174,7 +174,7 @@ Note that for SDK users, only sourcing this file is enough to configure the SDK 
 
 Download some tests, and try one of them:
 
-    $ git clone git@github.com:pulp-platform/rt-tests.git
+    $ git clone https://github.com/pulp-platform/rt-tests.git
     $ cd rt-tests/rt/threads
     $ make clean all run
 
@@ -208,7 +208,7 @@ After these steps, the new SDK is ready to be used.
 The SDK has some dependencies like the toolchains which must be built before the SDK can be built.
 To build everything including all the dependencies, first get the top SDK module, after you have configured your ssh key in gitlab:
 
-    $ git clone git@github.com:pulp-platform/pulp-sdk.git -b <sdb branch or tag>
+    $ git clone https://github.com/pulp-platform/pulp-sdk.git -b <sdb branch or tag>
 
 Take the *master* branch of the SDK if you want the latest features. However this branch may not be fully stable. The *release* branch can be retrieved to get the latest stable release. Otherwise any other branch or tag. There is always a tag whose name is the one of the SDK tag which is released.
 
@@ -241,7 +241,7 @@ Note that for SDK users, only sourcing this file is enough to configure the SDK 
 
 Download some tests, and try one of them:
 
-    $ git clone git@github.com:pulp-platform/rt-tests.git
+    $ git clone https://github.com/pulp-platform/rt-tests.git
     $ cd rt-tests/rt/threads
     $ make clean all run
 

--- a/project.cfg
+++ b/project.cfg
@@ -17,7 +17,7 @@ pulp_tools = plp.Module(
 
 rules = plp.Module(
   name  = 'pulp-rules',
-  url   = 'git@github.com:pulp-platform/pulp-rules.git',
+  url   = 'https://github.com/pulp-platform/pulp-rules.git',
   path  = 'tools/pulp-rules',
   deps  = [pulp_tools],
   steps = [
@@ -27,7 +27,7 @@ rules = plp.Module(
 
 runner = plp.Module(
   name  = 'runner',
-  url   = 'git@github.com:pulp-platform/runner.git',
+  url   = 'https://github.com/pulp-platform/runner.git',
   path  = 'tools/runner',
   steps = [
     plp.BuildStep('build', 'make sdk.build'),
@@ -39,7 +39,7 @@ runner = plp.Module(
 
 json_tools = plp.Module(
   name  = 'json-tools',
-  url   = 'git@github.com:pulp-platform/json-tools.git',
+  url   = 'https://github.com/pulp-platform/json-tools.git',
   path  = 'tools/json-tools',
   deps  = [],
   restrict   = "config.get('pulp_chip') != 'pulpissimo' and config.get('pulp_chip') != 'pulp'",
@@ -53,7 +53,7 @@ json_tools = plp.Module(
 
 archi = plp.Module(
   name  = 'archi',
-  url   = 'git@github.com:pulp-platform/archi.git',
+  url   = 'https://github.com/pulp-platform/archi.git',
   path  = 'runtime/archi',
   deps  = [rules],
   steps = [
@@ -64,7 +64,7 @@ archi = plp.Module(
 
 hal = plp.Module(
   name  = 'hal',
-  url   = 'git@github.com:pulp-platform/hal.git',
+  url   = 'https://github.com/pulp-platform/hal.git',
   path  = 'runtime/hal',
   deps  = [rules],
   steps = [
@@ -106,7 +106,7 @@ debug_bridge = plp.Module(
 
 pulp_debug_bridge = plp.Module(
   name  = 'debug-bridge2',
-  url   = 'git@github.com:pulp-platform/pulp-debug-bridge.git',
+  url   = 'https://github.com/pulp-platform/pulp-debug-bridge.git',
   path  = 'tools/pulp-debug-bridge',
   deps  = [json_tools, hal],
   steps = [
@@ -131,7 +131,7 @@ pc_analyzer = plp.Module(
 
 dpi_models = plp.Module(
   name  = 'dpi-models',
-  url   = 'git@github.com:pulp-platform/dpi-models.git',
+  url   = 'https://github.com/pulp-platform/dpi-models.git',
   path  = 'platform/dpi_models',
   deps  = [json_tools, pulp_debug_bridge],
   restrict   = "config.get('pulp_chip') != 'pulpissimo' and config.get('pulp_chip') != 'pulp'",
@@ -242,7 +242,7 @@ rtl_libs = plp.Module(
 
 pulp_rt = plp.Module(
   name       = 'pulp-rt',
-  url        = 'git@github.com:pulp-platform/pulp-rt.git',
+  url        = 'https://github.com/pulp-platform/pulp-rt.git',
   path       = 'runtime/pulp-rt',
   deps       = [rules,archi,hal],
   parameters = ['pulp_chip', 'pulp_compiler', 'pulp_rt_version', 'pulp_chip_version', 'install_name'],
@@ -380,7 +380,7 @@ riscv_gcc = plp.Module(
 
 pulp_riscv_gcc = plp.Module(
   name  = 'pulp_riscv_gcc',
-  url   = 'git@github.com:pulp-platform/pulp-riscv-gnu-toolchain.git',
+  url   = 'https://github.com/pulp-platform/pulp-riscv-gnu-toolchain.git',
   path  = 'tools/pulp-riscv-gcc',
   steps = [
     plp.BuildStep('checkout','make -f Makefile.pulp checkout'),
@@ -561,7 +561,7 @@ rt_tests = plp.Module(
 
 rt_examples = plp.Module(
   name     = 'pulp-rt-examples',
-  url      = 'git@github.com:pulp-platform/pulp-rt-examples.git',
+  url      = 'https://github.com/pulp-platform/pulp-rt-examples.git',
   path     = 'examples/pulp-rt-examples',
   testsets = ['testset.cfg']
 )


### PR DESCRIPTION
HTTPS supports anonymous cloning, whereas SSH does not.

Currently, cloning and initializing the SDK requires the user to login at GitHub via SSH.  This is inconvenient for end users who just want to "download" and use the SDK without having a GitHub account. This commit changes remote URLs to HTTPS, which does not require login.

One disadvantage of HTTPS over SSH is that pushing requires to enter username and password.  For most users this is not a problem, though, as they will have to set up their own fork as upstream repository anyway to be able to push.  For repository maintainers, `git remote set-url origin git@github.com:pulp-platform/pulp-sdk.git` switches the local clone back to the SSH remote.