### PR TITLE
scripts/*/setup.sh: disable build of unneeded modules from internal GitLab

### DIFF
--- a/scripts/bigpulp/setup.sh
+++ b/scripts/bigpulp/setup.sh
@@ -13,10 +13,7 @@ for m in \
     pulp-configs \
     pulp-rules \
     archi \
-    archi_analog \
-    hal_analog \
     hal \
-    jtag-bridge \
     debug-bridge2 \
     debug-bridge; \
 do

--- a/scripts/hero/setup.sh
+++ b/scripts/hero/setup.sh
@@ -13,10 +13,7 @@ for m in \
     pulp-configs \
     pulp-rules \
     archi \
-    archi_analog \
-    hal_analog \
     hal \
-    jtag-bridge \
     debug-bridge2 \
     debug-bridge; \
 do


### PR DESCRIPTION
This commit solves issue #28 on `hero-sdk`.