### PR TITLE
Replace GAP_SDK_HOME->PULP_SDK_HOME and GAP_RISCV_GCC_TOOLCHAIN->PULP…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 SHELL=bash
 
-ifndef GAP_SDK_HOME
+ifndef PULP_SDK_HOME
     $(error Please source the proper configuration first)
 endif
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Please, refer to the corresponding README for the installation.
 Once PULP toolchain is correctly installed, define the path in which there is toolchain bin folder:
 
 ~~~~~shell
-export GAP_RISCV_GCC_TOOLCHAIN=<INSTALL_DIR>
+export PULP_RISCV_GCC_TOOLCHAIN=<INSTALL_DIR>
 ~~~~~
 
 Source the file corresponding to the desired configuration:

--- a/configs/common.sh
+++ b/configs/common.sh
@@ -1,18 +1,19 @@
 #! /bin/bash
 
-export PULP_SDK_HOME=$GAP_SDK_HOME
-
-if [ -n "$GAP_RISCV_GCC_TOOLCHAIN_BASE" ]; then
-    export GAP_RISCV_GCC_TOOLCHAIN=$GAP_RISCV_GCC_TOOLCHAIN_BASE/1.3
+if [ -n "$PULP_RISCV_GCC_TOOLCHAIN_BASE" ]; then
+    export PULP_RISCV_GCC_TOOLCHAIN=$PULP_RISCV_GCC_TOOLCHAIN_BASE/1.3
 fi
 
-export PATH="$GAP_RISCV_GCC_TOOLCHAIN/bin":"$GAP_SDK_HOME/tools/bin":$PATH
+export PATH="$PULP_RISCV_GCC_TOOLCHAIN/bin":"$PULP_SDK_HOME/tools/bin":$PATH
 
+# keep compatibility with gap_sdk
+export GAP_SDK_HOME=$PULP_SDK_HOME
+export GAP_RISCV_GCC_TOOLCHAIN=$PULP_RISCV_GCC_TOOLCHAIN
 
-export TARGET_INSTALL_DIR=$GAP_SDK_HOME/install/$TARGET_CHIP
-export INSTALL_DIR=$GAP_SDK_HOME/install/workstation
+export TARGET_INSTALL_DIR=$PULP_SDK_HOME/install/$TARGET_CHIP
+export INSTALL_DIR=$PULP_SDK_HOME/install/workstation
 export DEP_DIRS=$INSTALL_DIR
-export RULES_DIR=$GAP_SDK_HOME/tools/rules
+export RULES_DIR=$PULP_SDK_HOME/tools/rules
 
 
 export PATH="$INSTALL_DIR/bin":$PATH
@@ -21,26 +22,25 @@ export PYTHONPATH=$INSTALL_DIR/python:$PYTHONPATH
 
 
 # Gapy
-export PATH=$GAP_SDK_HOME/tools/gapy:$PATH
-export PYTHONPATH=$GAP_SDK_HOME/tools/gap-configs/python:$PYTHONPATH
-export PYTHONPATH=$GAP_SDK_HOME/tools/gapy:$PYTHONPATH
-export PULP_CONFIGS_PATH=$GAP_SDK_HOME/tools/gap-configs/configs:$PULP_CONFIGS_PATH
+export PATH=$PULP_SDK_HOME/tools/gapy:$PATH
+export PYTHONPATH=$PULP_SDK_HOME/tools/gap-configs/python:$PYTHONPATH
+export PYTHONPATH=$PULP_SDK_HOME/tools/gapy:$PYTHONPATH
+export PULP_CONFIGS_PATH=$PULP_SDK_HOME/tools/gap-configs/configs:$PULP_CONFIGS_PATH
 
 # GVSOC
-export PULP_RISCV_GCC_TOOLCHAIN=$GAP_RISCV_GCC_TOOLCHAIN
 export PULP_SDK_INSTALL=$INSTALL_DIR
 export GVSOC_PATH=$INSTALL_DIR/python
-export GVSOC_INC_PATHS="$GAP_SDK_HOME/rtos/pulpos/gap_archi/include/archi/chips/$TARGET_NAME $GAP_SDK_HOME/rtos/pulpos/gap_archi/include $GAP_SDK_HOME/rtos/pulpos/pulp_archi/include"
+export GVSOC_INC_PATHS="$PULP_SDK_HOME/rtos/pulpos/gap_archi/include/archi/chips/$TARGET_NAME $PULP_SDK_HOME/rtos/pulpos/gap_archi/include $PULP_SDK_HOME/rtos/pulpos/pulp_archi/include"
 
 # FPGA
 #export PULP_
 
 # PulpOS 2
-export PULPOS_HOME=$GAP_SDK_HOME/rtos/pulpos/common
-export PULPOS_PULP_HOME=$GAP_SDK_HOME/rtos/pulpos/pulp
-export PULPOS_GAP8_HOME=$GAP_SDK_HOME/rtos/pulpos/gap8
-export PULPOS_GAP9_HOME=$GAP_SDK_HOME/rtos/pulpos/gap9
-export GAP_PULPOS_ARCHI=$GAP_SDK_HOME/rtos/pulpos/gap_archi
-export PULPOS_ARCHI=$GAP_SDK_HOME/rtos/pulpos/pulp_archi
-export PULPOS_HAL=$GAP_SDK_HOME/rtos/pulpos/pulp_hal
-export PMSIS_API=$GAP_SDK_HOME/rtos/pmsis/pmsis_api
+export PULPOS_HOME=$PULP_SDK_HOME/rtos/pulpos/common
+export PULPOS_PULP_HOME=$PULP_SDK_HOME/rtos/pulpos/pulp
+export PULPOS_GAP8_HOME=$PULP_SDK_HOME/rtos/pulpos/gap8
+export PULPOS_GAP9_HOME=$PULP_SDK_HOME/rtos/pulpos/gap9
+export GAP_PULPOS_ARCHI=$PULP_SDK_HOME/rtos/pulpos/gap_archi
+export PULPOS_ARCHI=$PULP_SDK_HOME/rtos/pulpos/pulp_archi
+export PULPOS_HAL=$PULP_SDK_HOME/rtos/pulpos/pulp_hal
+export PMSIS_API=$PULP_SDK_HOME/rtos/pmsis/pmsis_api

--- a/configs/pulp-open-rnnext.sh
+++ b/configs/pulp-open-rnnext.sh
@@ -4,11 +4,11 @@
 if [  -n "${ZSH_VERSION:-}" ]; then 
 	DIR="$(readlink -f -- "${(%):-%x}")"
 	DIRNAME="$(dirname $DIR)"
-	GAP_SDK_HOME=$(dirname $DIRNAME)
-	export GAP_SDK_HOME
+	PULP_SDK_HOME=$(dirname $DIRNAME)
+	export PULP_SDK_HOME
 	#echo $(dirname "$(readlink -f ${(%):-%N})")
 else
-	export GAP_SDK_HOME="$(dirname $(dirname "$(readlink -f "${BASH_SOURCE[0]}")"))"
+	export PULP_SDK_HOME="$(dirname $(dirname "$(readlink -f "${BASH_SOURCE[0]}")"))"
 fi
 
 export TARGET_CHIP_FAMILY="PULP"
@@ -24,4 +24,4 @@ export PULPOS_TARGET=pulp
 export PULPOS_SYSTEM=pulp
 export GAPY_TARGET=pulp_rnnext
 
-source $GAP_SDK_HOME/configs/common.sh
+source $PULP_SDK_HOME/configs/common.sh

--- a/configs/pulp-open.sh
+++ b/configs/pulp-open.sh
@@ -4,11 +4,11 @@
 if [  -n "${ZSH_VERSION:-}" ]; then 
 	DIR="$(readlink -f -- "${(%):-%x}")"
 	DIRNAME="$(dirname $DIR)"
-	GAP_SDK_HOME=$(dirname $DIRNAME)
-	export GAP_SDK_HOME
+	PULP_SDK_HOME=$(dirname $DIRNAME)
+	export PULP_SDK_HOME
 	#echo $(dirname "$(readlink -f ${(%):-%N})")
 else
-	export GAP_SDK_HOME="$(dirname $(dirname "$(readlink -f "${BASH_SOURCE[0]}")"))"
+	export PULP_SDK_HOME="$(dirname $(dirname "$(readlink -f "${BASH_SOURCE[0]}")"))"
 fi
 
 export TARGET_CHIP_FAMILY="PULP"
@@ -24,8 +24,8 @@ export PULPOS_TARGET=pulp
 export PULPOS_SYSTEM=pulp
 export GAPY_TARGET=pulp
 
-export PULPOS_MODULES="$GAP_SDK_HOME/rtos/pulpos/pulp $GAP_SDK_HOME/rtos/pmsis/pmsis_bsp"
+export PULPOS_MODULES="$PULP_SDK_HOME/rtos/pulpos/pulp $PULP_SDK_HOME/rtos/pmsis/pmsis_bsp"
 
-export GVSOC_MODULES="$GAP_SDK_HOME/tools/gvsoc/common $GAP_SDK_HOME/tools/gvsoc/pulp/models"
+export GVSOC_MODULES="$PULP_SDK_HOME/tools/gvsoc/common $PULP_SDK_HOME/tools/gvsoc/pulp/models"
 
-source $GAP_SDK_HOME/configs/common.sh
+source $PULP_SDK_HOME/configs/common.sh


### PR DESCRIPTION
…_RISCV_GCC_TOOLCHAIN in top-level of SDK

The change is only "superficial" and should keep compatibility with the gap_sdk.