### PR TITLE
Added documentation of workaround for GCC 11.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,13 @@ Compile the SDK with this command:
 make build
 ~~~~~
 
+There exists a bug in GCC 11.1.0 which fails the sdk build with the error `'this' pointer is null [-Werror=nonnull]`.
+If you encounter this bug use the following temporary workaround instead:
+
+~~~~~shell
+VP_WORKAROUND_NONNULL_BUG=yes make build
+~~~~~
+
 ## Test execution
 
 Some examples are availaible at https://github.com/GreenWaves-Technologies/pmsis_tests


### PR DESCRIPTION
Add documentation for the workaround in gvsoc that enables the build under recent GCC version.
This pull request is dependent on pulp-platform/gvsoc#15 and together fixes the fatal build error described in pulp-platform/pulp-sdk#102.