### PR TITLE
Add support for preloading

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,9 @@
+# the MAGICK_ROOT variable can be used to pass an alternative installation
+# prefix for the GraphicsMagick library. 
+ifdef MAGICK_ROOT
+export MAGICK_ROOT := $(realpath $(MAGICK_ROOT))
+endif
+
 SHELL=bash
 
 ifndef PULP_SDK_HOME

--- a/tools/dpi-models/Makefile
+++ b/tools/dpi-models/Makefile
@@ -1,7 +1,7 @@
 VSIM_DETECTED_PATH=$(dir $(shell which vsim))
 BUILD_DIR ?= build
 
-CFLAGS += -std=gnu++11 -MMD -MP -O3 -g
+CFLAGS += -std=c++11 -MMD -MP -O3 -g
 
 CFLAGS += -I$(INSTALL_DIR)/include -fPIC
 LDFLAGS += -L$(INSTALL_DIR)/lib -fPIC -shared -O3 -g -ljson

--- a/tools/dpi-models/models/camera/Makefile
+++ b/tools/dpi-models/models/camera/Makefile
@@ -2,11 +2,21 @@ DPI_MODELS += camera
 
 camera_SRCS = camera/camera.cpp
 
-MAGICK=$(shell pkg-config --exists GraphicsMagick --atleast-version=1.3.23 || echo FAILED)
+MAGICK_PKG_CFG_CMD := pkg-config
+ifdef MAGICK_ROOT
+# MAGICK_ROOT can be set to specify the root directory (containing e.g. /lib/,
+# /include/ etc) where GraphicsMagick was installed from source
+MAGICK_PKG_CFG_PATH := $(MAGICK_ROOT)/lib/pkgconfig:$(PKG_CONFIG_PATH)
+camera_CFLAGS += -Wl,-rpath=$(MAGICK_ROOT)/lib
+MAGICK_PKG_CFG_CMD := PKG_CONFIG_PATH=$(MAGICK_PKG_CFG_PATH) pkg-config
+endif
+
+MAGICK=$(shell $(MAGICK_PKG_CFG_CMD)  --exists GraphicsMagick --atleast-version=1.3.23 || echo FAILED)
+
 
 ifeq '$(MAGICK)' ''
-camera_CFLAGS += $(shell pkg-config GraphicsMagick --cflags)
+camera_CFLAGS += $(shell $(MAGICK_PKG_CFG_CMD) GraphicsMagick++ --cflags)
 camera_CFLAGS += -D__MAGICK__
-camera_LDFLAGS += -lGraphicsMagick++ -lGraphicsMagick
+camera_LDFLAGS := $(shell $(MAGICK_PKG_CFG_CMD) GraphicsMagick++ --libs)
 #LDFLAGS += $(shell Magick++-config --ldflags)
 endif

--- a/tools/gapy/runner/rtl/chips/pulp.py
+++ b/tools/gapy/runner/rtl/chips/pulp.py
@@ -34,6 +34,10 @@ class Runner(runner.rtl.rtl_runner.Runner, runner.chips.pulp.Runner):
         if os.environ.get('QUESTA_CXX') is not None:
             self.set_arg('-dpicpppath ' + os.environ.get('QUESTA_CXX'))
 
+        if os.environ.get('bootmode') is not None:
+            if os.environ.get('bootmode') == "preload":
+                self.set_arg('-gLOAD_L2=PRELOAD')
+
         self.set_arg('-permit_unmatched_virtual_intf')
         self.set_arg('+preload_file=efuse_preload.data')
         self.set_arg('-gBAUDRATE=115200')

--- a/tools/gvsoc/common/dpi-wrapper/Makefile
+++ b/tools/gvsoc/common/dpi-wrapper/Makefile
@@ -20,15 +20,15 @@ DPI_OBJS = $(patsubst %.cpp,$(BUILD_DIR)/dpi/%.o,$(patsubst %.c,$(BUILD_DIR)/dpi
 
 $(BUILD_DIR)/dpi/%.o: %.cpp
 	@mkdir -p $(basename $@)
-	g++ $(DPI_CFLAGS) -o $@ -c $<
+	$(CXX) $(DPI_CFLAGS) -o $@ -c $<
 
 $(BUILD_DIR)/dpi/%.o: %.c
 	@mkdir -p $(basename $@)
-	g++ $(DPI_CFLAGS) -o $@ -c $<
+	$(CXX) $(DPI_CFLAGS) -o $@ -c $<
 
 $(BUILD_DIR)/libgvsocdpi.so: $(DPI_OBJS)
 	@mkdir -p $(basename $@)
-	g++ -o $@ $^ $(DPI_LDFLAGS)
+	$(CXX) -o $@ $^ $(DPI_LDFLAGS)
 
 clean:
 	rm -rf $(BUILD_DIR)

--- a/tools/gvsoc/common/engine/Makefile
+++ b/tools/gvsoc/common/engine/Makefile
@@ -11,7 +11,7 @@ ifndef VERBOSE
 V = @
 endif
 
-CC = g++
+# CC = g++
 
 CFLAGS +=  -MMD -MP -O2 -g -fpic -Isrc -std=c++11 -Werror -Wall -I$(INSTALL_DIR)/include
 
@@ -53,58 +53,58 @@ endef
 $(ENGINE_BUILD_DIR)/%.o: src/%.c
 	@echo "CXX $<"
 	@mkdir -p $(basename $@)
-	$(V)$(CC) $(CFLAGS) -o $@ -c $<
+	$(V)$(CXX) $(CFLAGS) -o $@ -c $<
 
 $(ENGINE_BUILD_DIR)/%.o: src/%.cpp
 	@echo "CXX $<"
 	@mkdir -p $(basename $@)
-	$(V)$(CC) $(CFLAGS) -o $@ -c $<
+	$(V)$(CXX) $(CFLAGS) -o $@ -c $<
 
 $(ENGINE_BUILD_DIR)/dbg/%.o: src/%.c
 	@echo "CXX DBG $<"
 	@mkdir -p $(basename $@)
-	$(V)$(CC) $(CFLAGS) $(CFLAGS_DBG) -o $@ -c $<
+	$(V)$(CXX) $(CFLAGS) $(CFLAGS_DBG) -o $@ -c $<
 
 $(ENGINE_BUILD_DIR)/dbg/%.o: src/%.cpp
 	@echo "CXX DBG $<"
 	@mkdir -p $(basename $@)
-	$(V)$(CC) $(CFLAGS) $(CFLAGS_DBG) -o $@ -c $<
+	$(V)$(CXX) $(CFLAGS) $(CFLAGS_DBG) -o $@ -c $<
 
 $(ENGINE_BUILD_DIR)/sv/%.o: src/%.c
 	@echo "CXX SV $<"
 	@mkdir -p $(basename $@)
-	$(V)$(CC) $(CFLAGS) $(CFLAGS_SV) -o $@ -c $<
+	$(V)$(CXX) $(CFLAGS) $(CFLAGS_SV) -o $@ -c $<
 
 $(ENGINE_BUILD_DIR)/sv/%.o: src/%.cpp
 	@echo "CXX SV $<"
 	@mkdir -p $(basename $@)
-	$(V)$(CC) $(CFLAGS) $(CFLAGS_SV) -o $@ -c $<
+	$(V)$(CXX) $(CFLAGS) $(CFLAGS_SV) -o $@ -c $<
 
 $(ENGINE_BUILD_DIR)/libpulpvp.so: $(VP_OBJS)
 	@echo "CXX $<"
 	@mkdir -p $(basename $@)
-	$(V)$(CC) $^ -o $@ $(LDFLAGS) -shared -ldl -lpthread
+	$(V)$(CXX) $^ -o $@ $(LDFLAGS) -shared -ldl -lpthread
 
 
 $(ENGINE_BUILD_DIR)/libpulpvp-debug.so: $(VP_DBG_OBJS)
 	@echo "CXX DBG $<"
 	@mkdir -p $(basename $@)
-	$(V)$(CC) $^ -o $@ $(LDFLAGS) -shared  -ldl -lpthread
+	$(V)$(CXX) $^ -o $@ $(LDFLAGS) -shared  -ldl -lpthread
 
 $(ENGINE_BUILD_DIR)/libpulpvp-sv.so: $(VP_SV_OBJS)
 	@echo "CXX SV $<"
 	@mkdir -p $(basename $@)
-	$(V)$(CC) $^ -o $@ $(LDFLAGS) -shared  -ldl -lpthread
+	$(V)$(CXX) $^ -o $@ $(LDFLAGS) -shared  -ldl -lpthread
 
 $(ENGINE_BUILD_DIR)/gvsoc_launcher: $(ENGINE_BUILD_DIR)/main.o $(INSTALL_DIR)/lib/libpulpvp.so
 	@echo "CXX $<"
 	@mkdir -p `dirname $@`
-	$(V)$(CC) $(ENGINE_BUILD_DIR)/main.o -o $@ $(LDFLAGS) -lpthread -ldl -lpulpvp
+	$(V)$(CXX) $(ENGINE_BUILD_DIR)/main.o -o $@ $(LDFLAGS) -lpthread -ldl -lpulpvp
 
 $(ENGINE_BUILD_DIR)/gvsoc_launcher_debug: $(ENGINE_BUILD_DIR)/dbg/main.o $(INSTALL_DIR)/lib/libpulpvp-debug.so
 	@echo "CXX DBG $<"
 	@mkdir -p `dirname $@`
-	$(V)$(CC) $(ENGINE_BUILD_DIR)/dbg/main.o -o $@ $(LDFLAGS) -lpthread -ldl -lpulpvp-debug
+	$(V)$(CXX) $(ENGINE_BUILD_DIR)/dbg/main.o -o $@ $(LDFLAGS) -lpthread -ldl -lpulpvp-debug
 
 
 $(foreach file, $(VP_HEADERS), $(eval $(call declareInstallFile,$(file))))

--- a/tools/gvsoc/common/examples/launcher/Makefile
+++ b/tools/gvsoc/common/examples/launcher/Makefile
@@ -1,6 +1,6 @@
 BUILD_DIR ?= $(CURDIR)/build
 
-CC = g++
+# CC = g++
 
 CFLAGS +=  -MMD -MP -O2 -g -std=c++11 -Werror -Wall -I$(INSTALL_DIR)/include
 LDFLAGS += -O2 -g -Werror -Wall -L$(INSTALL_DIR)/lib -lpulpvp-debug
@@ -12,11 +12,11 @@ all: $(BUILD_DIR)/launcher
 
 $(BUILD_DIR)/%.o: %.cpp
 	mkdir -p $(dir $@)
-	$(CC) $(CFLAGS) -o $@ -c $<
+	$(CXX) $(CFLAGS) -o $@ -c $<
 
 $(BUILD_DIR)/launcher: $(OBJS)
 	mkdir -p $(dir $@)
-	$(CC) $^ -o $@ $(LDFLAGS)
+	$(CXX) $^ -o $@ $(LDFLAGS)
 
 clean:
 	rm -rf $(BUILD_DIR)

--- a/tools/gvsoc/common/launcher/Makefile
+++ b/tools/gvsoc/common/launcher/Makefile
@@ -6,7 +6,7 @@ LAUNCHER_BUILD_DIR = $(ROOT_VP_BUILD_DIR)/launcher
 -include $(INSTALL_DIR)/rules/vp_models.mk
 
 
-CC = g++
+# CC = g++
 
 CFLAGS +=  -MMD -MP -O2 -g -fpic -std=c++11 -Werror -Wall -I$(INSTALL_DIR)/include
 LDFLAGS += -O2 -g -shared -Werror -Wall -L$(INSTALL_DIR)/lib -Wl,--whole-archive -ljson -Wl,--no-whole-archive
@@ -30,15 +30,15 @@ endef
 
 $(LAUNCHER_BUILD_DIR)/%.o: src/%.c
 	@mkdir -p $(basename $@)
-	$(CC) $(CFLAGS) -o $@ -c $<
+	$(CXX) $(CFLAGS) -o $@ -c $<
 
 $(LAUNCHER_BUILD_DIR)/%.o: src/%.cpp
 	@mkdir -p $(basename $@)
-	$(CC) $(CFLAGS) -o $@ -c $<
+	$(CXX) $(CFLAGS) -o $@ -c $<
 
 $(LAUNCHER_BUILD_DIR)/libpulpvplauncher.so: $(LAUNCHER_OBJS)
 	@mkdir -p $(basename $@)
-	$(CC) $^ -o $@ $(LDFLAGS)
+	$(CXX) $^ -o $@ $(LDFLAGS)
 
 
 

--- a/tools/gvsoc/common/models/cpu/iss/Makefile.sa
+++ b/tools/gvsoc/common/models/cpu/iss/Makefile.sa
@@ -14,7 +14,7 @@ $(BUILD_DIR)/riscy_decoder_gen.cpp: isa_gen/isa_riscv_gen.py isa_gen/isa_gen.py
 	isa_gen/isa_riscv_gen.py --source-file=$(BUILD_DIR)/riscy_decoder_gen.cpp --header-file=$(BUILD_DIR)/riscy_decoder_gen.hpp
 
 $(BUILD_DIR)/pulp_iss: $(SA_ISS_SRCS)
-	g++ -o $@ $^ $(SA_ISS_CFLAGS) $(SA_ISS_LDFLAGS)
+	$(CXX) -o $@ $^ $(SA_ISS_CFLAGS) $(SA_ISS_LDFLAGS)
 
 $(INSTALL_DIR)/bin/pulp_iss: $(BUILD_DIR)/pulp_iss
 

--- a/tools/gvsoc/common/vp_models.mk
+++ b/tools/gvsoc/common/vp_models.mk
@@ -5,8 +5,9 @@ VP_PY_INSTALL_PATH ?= $(INSTALL_DIR)/python
 
 VP_MAKEFILE_LIST = $(addsuffix /Makefile,$(VP_DIRS))
 
-CPP=g++
-CC=gcc
+# CPP=g++
+CPP = $(CXX)
+# CC=gcc
 
 ifndef VERBOSE
 V = @

--- a/tools/gvsoc/pulp/models/pulp/ne16/src/ne16_streamin.cpp
+++ b/tools/gvsoc/pulp/models/pulp/ne16/src/ne16_streamin.cpp
@@ -44,7 +44,12 @@ void Ne16::constant_setup() {
 
 void Ne16::streamin_setup() {
 
-  auto base_addr_streamin = this->outfeat_ptr + (this->i_major*this->FILTER_SIZE*this->w_out*this->k_out + this->j_major*this->FILTER_SIZE*this->k_out + this->k_out_major*this->TP_OUT) * 4;
+  auto tp = this->depthwise ? this->TP_IN : this->TP_OUT;
+
+  auto outfeat_hom_iter = this->FILTER_SIZE * this->outfeat_d2_stride;
+  auto outfeat_wom_iter = this->FILTER_SIZE * this->outfeat_d1_stride;
+
+  auto base_addr_streamin = this->outfeat_ptr + this->i_major*outfeat_hom_iter + this->j_major*outfeat_wom_iter + this->k_out_major*tp*this->quantization_bits/8;
 
   auto k_out_lim = this->depthwise ? 1 :
                    (this->k_out_major == this->subtile_nb_ko-1 && this->subtile_rem_ko != this->TP_OUT && this->subtile_rem_ko != 0) ? this->subtile_rem_ko : this->TP_OUT;

--- a/tools/gvsoc/pulp/models/pulp/ne16/src/ne16_streamout.cpp
+++ b/tools/gvsoc/pulp/models/pulp/ne16/src/ne16_streamout.cpp
@@ -24,7 +24,10 @@ void Ne16::streamout_setup() {
 
   auto tp = this->depthwise ? this->TP_IN : this->TP_OUT;
 
-  auto base_addr_y = this->outfeat_ptr + (this->i_major*this->FILTER_SIZE*this->w_out*this->k_out + this->j_major*this->FILTER_SIZE*this->k_out + this->k_out_major*tp) * this->quantization_bits/8;
+  auto outfeat_hom_iter = this->FILTER_SIZE * this->outfeat_d2_stride;
+  auto outfeat_wom_iter = this->FILTER_SIZE * this->outfeat_d1_stride;
+
+  auto base_addr_y = this->outfeat_ptr + this->i_major*outfeat_hom_iter + this->j_major*outfeat_wom_iter + this->k_out_major*tp*this->quantization_bits/8;
 
   auto streamout_k_out_lim = !this->depthwise ? this->mv_k_out_lim : (this->k_out_major == this->subtile_nb_ko-1 && this->subtile_rem_ko != this->TP_IN && this->subtile_rem_ko != 0) ? this->subtile_rem_ko : this->TP_IN;
 ;

--- a/tools/pulp-debug-bridge/Makefile
+++ b/tools/pulp-debug-bridge/Makefile
@@ -94,10 +94,10 @@ install:
 
 $(BUILD_DIR)/%.o: %.cpp
 	@mkdir -p $(basename $@)
-	g++ $(CFLAGS) -o $@ -c $<
+	$(CXX) $(CFLAGS) -o $@ -c $<
 
 $(BUILD_DIR)/libpulpdebugbridge.so: $(OBJS)
-	g++ -o $@ $^ $(LDFLAGS)
+	$(CXX) -o $@ $^ $(LDFLAGS)
 
 $(INSTALL_DIR)/lib/libpulpdebugbridge.so: $(BUILD_DIR)/libpulpdebugbridge.so
 	install -D $< $@


### PR DESCRIPTION
Add (back) support for preloading L2 and L1 memory in RTL simulations. The "best" option might be to rely on information directly in the SDK, but in this PR instead the strategy is to rely on an external `mem.json` file distributed together with the PULP RTL, inside the ROOT/sim folder of each given PULP chip, to describe the memory architecture.
For example, the typical architecture of a PULPissimo SoC with 32+32 KiB of private L2 and 448 KiB of shared L2 divided in 4 word-interleaved banks is described as follows:

```
  {
      "pri0": {
          "base"   : "0x1c000000",
          "length" : "32768",
          "instance": "/tb_pulp/i_dut/soc_domain_i/pulp_soc_i/l2_ram_i/bank_sram_pri0_i/sram",
          "interleaving": "None"
      },
      "pri1": {
          "base"   : "0x1c008000",
          "length" : "32768",
          "instance": "/tb_pulp/i_dut/soc_domain_i/pulp_soc_i/l2_ram_i/bank_sram_pri1_i/sram",
          "interleaving": "None"
      },
      "l2_0": {
          "base"   : "0x1c010000",
          "length" : "458752",
          "instance": "/tb_pulp/i_dut/soc_domain_i/pulp_soc_i/l2_ram_i/CUTS[0]/bank_i/sram",
          "interleaving": "4",
          "interleaving_bank": "0"
      },
      "l2_1": {
          "base"   : "0x1c010000",
          "length" : "458752",
          "instance": "/tb_pulp/i_dut/soc_domain_i/pulp_soc_i/l2_ram_i/CUTS[1]/bank_i/sram",
          "interleaving": "4",
          "interleaving_bank": "1"
      },
      "l2_2": {
          "base"   : "0x1c010000",
          "length" : "458752",
          "instance": "/tb_pulp/i_dut/soc_domain_i/pulp_soc_i/l2_ram_i/CUTS[2]/bank_i/sram",
          "interleaving": "4",
          "interleaving_bank": "2"
      },
      "l2_3": {
          "base"   : "0x1c010000",
          "length" : "458752",
          "instance": "/tb_pulp/i_dut/soc_domain_i/pulp_soc_i/l2_ram_i/CUTS[3]/bank_i/sram",
          "interleaving": "4",
          "interleaving_bank": "3"
      }
  }
```

The SDK will automatically generate one file for each JSON dictionary entry inside `vectors`, but keep the JTAG loading method  by default. To switch to preloading, one can set the `bootmode` env variable on the fly while calling the Make command:

```
  make all run platform=rtl bootmode=preload
```