### PR TITLE
Build __float128 in flexfloat only if it is actually used

### DIFF
--- a/tools/gvsoc/common/models/cpu/iss/flexfloat/flexfloat.c
+++ b/tools/gvsoc/common/models/cpu/iss/flexfloat/flexfloat.c
@@ -381,6 +381,7 @@ INLINE void ff_init_longdouble(flexfloat_t *obj, long double value, flexfloat_de
     flexfloat_sanitize(obj);
 }
 
+#ifdef FLEXFLOAT_ON_QUAD
 INLINE void ff_init_float128(flexfloat_t *obj, __float128 value, flexfloat_desc_t desc) {
     obj->value = (fp_t)value;
     #ifdef FLEXFLOAT_TRACKING
@@ -391,6 +392,7 @@ INLINE void ff_init_float128(flexfloat_t *obj, __float128 value, flexfloat_desc_
     obj->desc = desc;
     flexfloat_sanitize(obj);
 }
+#endif
 
 INLINE void ff_init_int(flexfloat_t *obj, int value, flexfloat_desc_t desc) {
     obj->value = (fp_t)value;
@@ -447,9 +449,11 @@ INLINE long double ff_get_longdouble(const flexfloat_t *obj) {
     return (long double)(*((const fp_t *)(&(obj->value))));
 }
 
+#ifdef FLEXFLOAT_ON_QUAD
 INLINE __float128 ff_get_float128(const flexfloat_t *obj) {
     return (__float128)(*((const fp_t *)(&(obj->value))));
 }
+#endif
 
 
 // Arithmetics

--- a/tools/gvsoc/common/models/cpu/iss/flexfloat/flexfloat.h
+++ b/tools/gvsoc/common/models/cpu/iss/flexfloat/flexfloat.h
@@ -207,7 +207,9 @@ void ff_init(flexfloat_t *obj, flexfloat_desc_t desc);
 void ff_init_float(flexfloat_t *obj, float value, flexfloat_desc_t desc);
 void ff_init_double(flexfloat_t *obj, double value, flexfloat_desc_t desc);
 void ff_init_longdouble(flexfloat_t *obj, long double value, flexfloat_desc_t desc);
-void ff_init_float128(flexfloat_t *obj, __float128 value, flexfloat_desc_t desc);
+#ifdef FLOAT_ON_QUAD
+  void ff_init_float128(flexfloat_t *obj, __float128 value, flexfloat_desc_t desc);
+#endif
 void ff_init_int(flexfloat_t *obj, int value, flexfloat_desc_t desc);
 void ff_init_long(flexfloat_t *obj, long value, flexfloat_desc_t desc);
 void ff_cast(flexfloat_t *obj, const flexfloat_t *source, flexfloat_desc_t desc);
@@ -217,7 +219,9 @@ void ff_cast(flexfloat_t *obj, const flexfloat_t *source, flexfloat_desc_t desc)
 float ff_get_float(const flexfloat_t *obj);
 double ff_get_double(const flexfloat_t *obj);
 long double ff_get_longdouble(const flexfloat_t *obj);
-__float128 ff_get_float128(const flexfloat_t *obj);
+#ifdef FLOAT_ON_QUAD
+  __float128 ff_get_float128(const flexfloat_t *obj);
+#endif
 
 
 // Artihmetic operators


### PR DESCRIPTION
By default, it is not: therefore, gvsoc can be built also on ARM64.