### PR TITLE
Allow custom vsim if `$VSIM` is defined

### DIFF
--- a/tools/gapy/configs/platforms/rtl.json
+++ b/tools/gapy/configs/platforms/rtl.json
@@ -12,7 +12,7 @@
             "rtl": {
                 "commands": {
                     "shell": {
-                        "executable": "vsim",
+                        "executable": "${VSIM:-vsim}",
                         "args_eval": [
                             "\"-64\"",
                             "\"-c\"",
@@ -21,7 +21,7 @@
                         ]
                     },
                     "gui": {
-                        "executable": "vsim",
+                        "executable": "${VSIM:-vsim}",
                         "args_eval": [
                             "\"-64\"",
                             "\"-do 'source \" + os.environ.get(\"VSIM_PATH\") +  \"/tcl_files/config/run_and_exit.tcl'\"",


### PR DESCRIPTION
If a custom vsim command (e.g. for using alternative versions) is defined using `$VSIM`, this will be used instead of the default `vsim`. If this environment variable is not defined, default behavior is to use `vsim`.