### PR TITLE
Fix dma when using `copy.merge`

### DIFF
--- a/rtos/pmsis/pmsis_api/include/pmsis/cluster/dma/cl_dma.h
+++ b/rtos/pmsis/pmsis_api/include/pmsis/cluster/dma/cl_dma.h
@@ -189,9 +189,9 @@ static inline void pi_cl_dma_wait(void *copy);
 /// @cond IMPLEM
 
 #define CL_DMA_COMMON                           \
+    uint32_t id;                                \
     uint32_t ext;                               \
     uint32_t loc;                               \
-    uint32_t id;                                \
     uint16_t size;                              \
     pi_cl_dma_dir_e dir;                        \
     uint8_t merge;

--- a/rtos/pulpos/common/include/pos/implem/dma.h
+++ b/rtos/pulpos/common/include/pos/implem/dma.h
@@ -24,7 +24,7 @@
 
 struct pi_cl_dma_cmd_s
 {
-  int id;
+  uint32_t id;
   struct pi_cl_dma_cmd_s *next;
 };
 


### PR DESCRIPTION
Due to the type cast here: https://github.com/pulp-platform/pulp-sdk/blob/aee8a8acb4216da2c5e59cfe7e9f11ce3c04184b/rtos/pulpos/common/include/pos/implem/dma.h#L152
transfers are not properly handled when using the `merge` feature in the copy struct. This can cause stalls as the DMA is not properly executing transfers. This PR fixes part of the issue of the type cast, ensuring the ID field is the same in the `cmd` and `copy` struct. Other issues may come up when using the `next` field of the `cmd` struct.