### PR TITLE
This commit adds support for compiling with the PULP LLVM toolchain.

### DIFF
--- a/configs/common.sh
+++ b/configs/common.sh
@@ -4,7 +4,13 @@ if [ -n "$PULP_RISCV_GCC_TOOLCHAIN_BASE" ]; then
     export PULP_RISCV_GCC_TOOLCHAIN=$PULP_RISCV_GCC_TOOLCHAIN_BASE/1.3
 fi
 
-export PATH="$PULP_RISCV_GCC_TOOLCHAIN/bin":"$PULP_SDK_HOME/tools/bin":$PATH
+if [ -n "$PULP_RISCV_GCC_TOOLCHAIN" ]; then
+    export PATH="$PULP_RISCV_GCC_TOOLCHAIN/bin":"$PULP_SDK_HOME/tools/bin":$PATH
+fi
+
+if [ -n "$PULP_RISCV_LLVM_TOOLCHAIN" ]; then
+    export PATH="$PULP_RISCV_LLVM_TOOLCHAIN/bin":"$PULP_SDK_HOME/tools/bin":$PATH
+fi
 
 # keep compatibility with gap_sdk
 export GAP_SDK_HOME=$PULP_SDK_HOME

--- a/rtos/pmsis/pmsis_bsp/fs/read_fs/read_fs.c
+++ b/rtos/pmsis/pmsis_bsp/fs/read_fs/read_fs.c
@@ -140,7 +140,7 @@ static void __pi_fs_free(pi_read_fs_t *fs)
 static void __pi_fs_mount_step(void *arg)
 {
     pi_read_fs_t *fs = (pi_read_fs_t *) arg;
-    const pi_partition_table_t partition_table = NULL;
+    pi_partition_table_t partition_table = NULL;
     const pi_partition_t *readfs_partition = NULL;
     pi_err_t rc;
     

--- a/rtos/pulpos/common/include/pos/data/data.h
+++ b/rtos/pulpos/common/include/pos/data/data.h
@@ -38,7 +38,7 @@
 #ifndef LANGUAGE_ASSEMBLY
 
 // We cannot use tiny attribute if we use a generic riscv toolchain or LLVM or we there is fc specific memeory (TCDM or L2)
-#if (defined(ARCHI_HAS_FC_TCDM) || defined(ARCHI_HAS_L2_ALIAS)) && !defined(__LLVM__) && !defined(__RISCV_GENERIC__) && defined(CONFIG_NO_STD_RELOC)
+#if (defined(ARCHI_HAS_FC_TCDM) || defined(ARCHI_HAS_L2_ALIAS)) && !defined(__RISCV_GENERIC__) && defined(CONFIG_NO_STD_RELOC)
 #define POS_FC_TINY_ATTRIBUTE __attribute__ ((tiny))
 #else
 #define POS_FC_TINY_ATTRIBUTE

--- a/rtos/pulpos/common/kernel/crt0.S
+++ b/rtos/pulpos/common/kernel/crt0.S
@@ -36,7 +36,10 @@ pos_init_entry:
     andi    a1, a0, 0x1f
     srli    a0, a0, 5
     li      a2, ARCHI_FC_CID
-    bne     a0, a2, pos_pe_start
+#    bne     a0, a2, pos_pe_start
+    beq     a0, a2, label0
+    j      pos_pe_start
+label0:
 
 #endif
 

--- a/rtos/pulpos/common/kernel/soc_event_v2_itc.S
+++ b/rtos/pulpos/common/kernel/soc_event_v2_itc.S
@@ -41,6 +41,7 @@
     sw  x10, 8(sp)
     sw  x11, 12(sp)
     sw  x12, 16(sp)
+    sw  t0, 20(sp)
 
 
 
@@ -125,5 +126,6 @@ pos_soc_event_handler_end_asm:
     lw  x10, 8(sp)
     lw  x11, 12(sp)
     lw  x12, 16(sp)
+    lw  t0, 20(sp)
     add sp, sp, 128
     mret

--- a/rtos/pulpos/common/kernel/task_asm.S
+++ b/rtos/pulpos/common/kernel/task_asm.S
@@ -80,6 +80,7 @@ pos_task_remote_enqueue:
     sw  a0, -12(sp)
     sw  a1, -16(sp)
     sw  a2, -20(sp)
+    sw  t0, -24(sp)
 
     li   x8, ARCHI_NB_CLUSTER
     la   x9, pos_cluster
@@ -129,6 +130,7 @@ pos_task_remote_enqueue_event_loop_cluster_continue:
     lw  a0, -12(sp)
     lw  a1, -16(sp)
     lw  a2, -20(sp)
+    lw  t0, -24(sp)
 
     mret
 

--- a/rtos/pulpos/common/lib/omp/omp.c
+++ b/rtos/pulpos/common/lib/omp/omp.c
@@ -104,7 +104,7 @@ static void __rt_omp_init(int exec_main)
 
   initTeam(_this, &_this->plainTeam);
 
-#ifdef __LLVM__
+#ifdef __clang__
   _this->numThreads = 0;
 #endif
 

--- a/rtos/pulpos/common/lib/omp/ompRt.h
+++ b/rtos/pulpos/common/lib/omp/ompRt.h
@@ -59,7 +59,7 @@ typedef struct {
 typedef struct {
   //ompTask_t *taskPool;
   omp_team_t plainTeam;
-#ifdef __LLVM__
+#ifdef __clang__
   int numThreads;
 #endif
   unsigned short coreMask;

--- a/rtos/pulpos/common/rules/pulpos/default_rules.mk
+++ b/rtos/pulpos/common/rules/pulpos/default_rules.mk
@@ -29,6 +29,13 @@ ifdef PULP_RISCV_GCC_TOOLCHAIN
 PULP_CC := $(PULP_RISCV_GCC_TOOLCHAIN)/bin/$(PULP_CC)
 PULP_LD := $(PULP_RISCV_GCC_TOOLCHAIN)/bin/$(PULP_LD)
 PULP_AR := $(PULP_RISCV_GCC_TOOLCHAIN)/bin/$(PULP_AR)
+PULP_CFLAGS += -fno-jump-tables -fno-tree-loop-distribute-patterns
+endif
+ifdef PULP_RISCV_LLVM_TOOLCHAIN
+PULP_CC := $(PULP_RISCV_LLVM_TOOLCHAIN)/bin/clang
+PULP_LD := /home/tagliavini/pulpnn-isa/pulp-riscv-gnu-toolchain/INSTALL/bin/$(PULP_LD)
+#PULP_LD := $(PULP_RISCV_LLVM_TOOLCHAIN)/bin/$(PULP_LD)
+PULP_AR := $(PULP_RISCV_LLVM_TOOLCHAIN)/bin/$(PULP_AR)
 endif
 endif
 endif
@@ -37,7 +44,6 @@ VPATH = $(PULPOS_HOME) $(PULPOS_MODULES)
 
 include $(PULPOS_HOME)/rules/pulpos/src.mk
 
-PULP_CFLAGS += -fno-jump-tables -fno-tree-loop-distribute-patterns
 
 ifeq '$(CONFIG_LIBC_MINIMAL)' '1'
 PULP_APP_CFLAGS += -I$(PULPOS_HOME)/lib/libc/minimal/include

--- a/rtos/pulpos/common/rules/pulpos/default_rules.mk
+++ b/rtos/pulpos/common/rules/pulpos/default_rules.mk
@@ -33,8 +33,7 @@ PULP_CFLAGS += -fno-jump-tables -fno-tree-loop-distribute-patterns
 endif
 ifdef PULP_RISCV_LLVM_TOOLCHAIN
 PULP_CC := $(PULP_RISCV_LLVM_TOOLCHAIN)/bin/clang
-PULP_LD := /home/tagliavini/pulpnn-isa/pulp-riscv-gnu-toolchain/INSTALL/bin/$(PULP_LD)
-#PULP_LD := $(PULP_RISCV_LLVM_TOOLCHAIN)/bin/$(PULP_LD)
+PULP_LD := $(PULP_RISCV_LLVM_TOOLCHAIN)/bin/$(PULP_LD)
 PULP_AR := $(PULP_RISCV_LLVM_TOOLCHAIN)/bin/$(PULP_AR)
 endif
 endif

--- a/rtos/pulpos/pulp/rules/pulpos/targets/pulp.mk
+++ b/rtos/pulpos/pulp/rules/pulpos/targets/pulp.mk
@@ -2,9 +2,23 @@ CONFIG_NB_CLUSTER_PE ?= 8
 
 PULP_LDFLAGS      += 
 PULP_CFLAGS       +=  -D__riscv__
+
+ifneq ($(and $(PULP_RISCV_GCC_TOOLCHAIN),$(PULP_RISCV_LLVM_TOOLCHAIN)),)	
+$(error PULP_RISCV_GCC_TOOLCHAIN and PULP_RISCV_LLVM_TOOLCHAIN cannot be set both at the same time)
+endif
+
+ifdef PULP_RISCV_GCC_TOOLCHAIN
 PULP_ARCH_CFLAGS ?=  -march=rv32imcxgap9 -mPE=$(CONFIG_NB_CLUSTER_PE) -mFC=1
 PULP_ARCH_LDFLAGS ?=  -march=rv32imcxgap9 -mPE=$(CONFIG_NB_CLUSTER_PE) -mFC=1
 PULP_ARCH_OBJDFLAGS ?= -Mmarch=rv32imcxgap9
+endif
+
+ifdef PULP_RISCV_LLVM_TOOLCHAIN
+PULP_ARCH_CFLAGS ?=   -target riscv32-unknown-elf -march=rv32imcxpulpv2 --sysroot=${PULP_RISCV_LLVM_TOOLCHAIN}/riscv32-unknown-elf -ffreestanding
+PULP_ARCH_LDFLAGS ?=  -march=rv32imcxpulpv2
+PULP_ARCH_OBJDFLAGS ?= -Mmarch=rv32imcxpulpv2
+endif
+
 PULP_CFLAGS    += -fdata-sections -ffunction-sections -include pos/chips/pulp/config.h -I$(PULPOS_PULP_HOME)/include/pos/chips/pulp -I$(PULP_EXT_LIBS)/include
 ifeq '$(CONFIG_OPENMP)' '1'
 PULP_CFLAGS    += -fopenmp -mnativeomp

--- a/rtos/pulpos/pulp_archi/include/archi/gap_utils.h
+++ b/rtos/pulpos/pulp_archi/include/archi/gap_utils.h
@@ -21,7 +21,7 @@
 static inline unsigned int __attribute__ ((always_inline)) ExtInsMaskFast_archi(unsigned int Size, unsigned int Offset) { return ((((Size-1))<<5)|(Offset)); }
 static inline unsigned int __attribute__ ((always_inline)) ExtInsMaskSafe_archi(unsigned int Size, unsigned int Offset) { return ((((Size-1)&0x1F)<<5)|(Offset&0x1F)); }
 
-#if defined(__riscv__) && !defined(__LLVM__) && !defined(RV_ISA_RV32)
+#if defined(__riscv__) && !defined(RV_ISA_RV32)
 #define GAP_WRITE_VOL(base, offset, value) __builtin_pulp_write_base_off_v((value), (base), (offset))
 #define GAP_WRITE(base, offset, value)     __builtin_pulp_OffsetedWrite((value), (int *)(base), (offset))
 #define GAP_READ(base, offset)             __builtin_pulp_OffsetedRead((int *)(base), (offset))

--- a/rtos/pulpos/pulp_archi/include/archi/utils.h
+++ b/rtos/pulpos/pulp_archi/include/archi/utils.h
@@ -50,7 +50,7 @@
 #define archi_read(add)          (*(volatile unsigned int *)(long)(add))
 
 
-#if defined(__riscv__) && !defined(__LLVM__) && !defined(RV_ISA_RV32)
+#if defined(__riscv__) && !defined(RV_ISA_RV32)
 #define ARCHI_WRITE_VOL(base, offset, value) __builtin_pulp_write_base_off_v((value), (base), (offset))
 #define ARCHI_WRITE(base, offset, value)     __builtin_pulp_OffsetedWrite((value), (int *)(base), (offset))
 #define ARCHI_READ(base, offset)             __builtin_pulp_OffsetedRead((int *)(base), (offset))

--- a/rtos/pulpos/pulp_hal/include/hal/dma/mchan_v6.h
+++ b/rtos/pulpos/pulp_hal/include/hal/dma/mchan_v6.h
@@ -248,7 +248,7 @@ static inline unsigned int plp_dma_status();
 
 /// @cond IMPLEM
 
-#if defined(__riscv__) && !defined(RV_ISA_RV32) && !defined(__LLVM__)
+#if defined(__riscv__) && !defined(RV_ISA_RV32)
 #define DMA_WRITE(value, offset) __builtin_pulp_OffsetedWrite((value), (int *)ARCHI_DEMUX_PERIPHERALS_ADDR, ARCHI_MCHAN_DEMUX_OFFSET + (offset))
 #define DMA_READ(offset) __builtin_pulp_OffsetedRead((int *)ARCHI_DEMUX_PERIPHERALS_ADDR, ARCHI_MCHAN_DEMUX_OFFSET + (offset))
 #else

--- a/rtos/pulpos/pulp_hal/include/hal/dma/mchan_v7.h
+++ b/rtos/pulpos/pulp_hal/include/hal/dma/mchan_v7.h
@@ -258,7 +258,7 @@ static inline unsigned int plp_dma_status();
 
 /// @cond IMPLEM
 
-#if defined(__riscv__) && !defined(RV_ISA_RV32) && !defined(__LLVM__)
+#if defined(__riscv__) && !defined(RV_ISA_RV32)
 #define DMA_WRITE(value, offset) __builtin_pulp_OffsetedWrite((value), (int *)ARCHI_MCHAN_EXT_ADDR, (offset))
 #define DMA_READ(offset) __builtin_pulp_OffsetedRead((int *)ARCHI_MCHAN_EXT_ADDR, (offset))
 #else

--- a/rtos/pulpos/pulp_hal/include/hal/pulp_io.h
+++ b/rtos/pulpos/pulp_hal/include/hal/pulp_io.h
@@ -24,7 +24,7 @@
 #define pulp_write32(add, val_) (*(volatile unsigned int *)(long)(add) = val_)
 #define pulp_write(add, val_) (*(volatile unsigned int *)(long)(add) = val_)
 
-#if 1
+#if !defined(__clang__)
 
 #define pulp_read8(add) (*(volatile unsigned char *)(long)(add))
 #define pulp_read16(add) (*(volatile unsigned short *)(long)(add))
@@ -37,7 +37,6 @@ static inline uint8_t pulp_read8(uint32_t add)
 {
   __asm__ __volatile__ ("" : : : "memory");
   uint8_t result = *(volatile uint8_t *)add;
-  asm volatile("l.nop;");
   __asm__ __volatile__ ("" : : : "memory");
   return result;
 }
@@ -46,7 +45,6 @@ static inline uint16_t pulp_read16(uint32_t add)
 {
   __asm__ __volatile__ ("" : : : "memory");
   uint16_t result = *(volatile uint16_t *)add;
-  asm volatile("nop;");
   __asm__ __volatile__ ("" : : : "memory");
   return result;
 }
@@ -55,7 +53,6 @@ static inline uint32_t pulp_read32(uint32_t add)
 {
   __asm__ __volatile__ ("" : : : "memory");
   uint32_t result = *(volatile uint32_t *)add;
-  asm volatile("nop;");
   __asm__ __volatile__ ("" : : : "memory");
   return result;
 }
@@ -64,14 +61,13 @@ static inline uint32_t pulp_read(uint32_t add)
 {
   __asm__ __volatile__ ("" : : : "memory");
   uint32_t result = *(volatile uint32_t *)add;
-  asm volatile("nop;");
   __asm__ __volatile__ ("" : : : "memory");
   return result;
 }
 
 #endif
 
-#if defined(__riscv__) && !defined(RV_ISA_RV32) && !defined(__LLVM__)
+#if defined(__riscv__) && !defined(RV_ISA_RV32)
 #define IP_WRITE_VOL(base, offset, value) __builtin_pulp_write_base_off_v((value), (base), (offset))
 #define IP_WRITE(base, offset, value) __builtin_pulp_OffsetedWrite((value), (int *)(base), (offset))
 #if !defined(CONFIG_PULP)

--- a/rtos/pulpos/pulp_hal/include/hal/riscv/riscv_v4.h
+++ b/rtos/pulpos/pulp_hal/include/hal/riscv/riscv_v4.h
@@ -32,7 +32,7 @@
 
 
 
-#if defined(__OPTIMIZE__) && defined(CORE_PULP_BUILTINS) && !defined(__LLVM__)
+#if defined(__OPTIMIZE__) && defined(CORE_PULP_BUILTINS)
 
 static inline unsigned int hal_spr_read_then_clr(unsigned int reg, unsigned int val)
 {
@@ -56,10 +56,6 @@ static inline unsigned int hal_spr_read(unsigned int reg)
 
 #else
 
-#if defined(__LLVM__)
-
-#else
- 
 #define hal_spr_read_then_clr(reg,val) \
   ({ \
     int state; \
@@ -86,29 +82,11 @@ do { \
   result; \
 })
 
-#endif
 
 #endif
 
 
-
-
-
-#if defined(__LLVM__)
-
-#define csr_read(csr)           \
-({                \
-  register unsigned int __v;       \
-  __asm__ __volatile__ ("csrr %0, " #csr      \
-            : "=r" (__v));      \
-  __v;              \
-})
-
-#define hal_mepc_read() csr_read(0x341)
-
-#else
 #define hal_mepc_read() hal_spr_read(RV_CSR_MEPC)
-#endif
 
 static inline unsigned int core_id() {
   int hart_id;
@@ -222,23 +200,6 @@ static inline __attribute__((always_inline)) unsigned int hal_is_fc() {
 
 
 
-#if defined(__LLVM__)
-
-static inline int hal_irq_disable()
-{
-  return 0;
-}
-
-static inline void hal_irq_restore(int state)
-{
-}
-
-static inline void hal_irq_enable()
-{
-}
-
-#else
-
 static inline int hal_irq_disable()
 {
   int irq = hal_spr_read_then_clr(0x300, 0x1<<3);
@@ -261,7 +222,6 @@ static inline void hal_irq_enable()
   hal_spr_read_then_set(0x300, 0x1<<3);
 }
 
-#endif
 
 /*
  * PERFORMANCE COUNTERS

--- a/rtos/pulpos/pulp_hal/include/hal/riscv/riscv_v5.h
+++ b/rtos/pulpos/pulp_hal/include/hal/riscv/riscv_v5.h
@@ -32,7 +32,7 @@
 
 
 
-#if defined(__OPTIMIZE__) && defined(CORE_PULP_BUILTINS) && !defined(__LLVM__)
+#if defined(__OPTIMIZE__) && defined(CORE_PULP_BUILTINS)
 
 static inline unsigned int hal_spr_read_then_clr(unsigned int reg, unsigned int val)
 {
@@ -56,9 +56,6 @@ static inline unsigned int hal_spr_read(unsigned int reg)
 
 #else
 
-#if defined(__LLVM__)
-
-#else
  
 #define hal_spr_read_then_clr(reg,val) \
   ({ \
@@ -109,27 +106,11 @@ do { \
 
 #endif
 
-#endif
 
 
 
 
-
-#if defined(__LLVM__)
-
-#define csr_read(csr)           \
-({                \
-  register unsigned int __v;       \
-  __asm__ __volatile__ ("csrr %0, " #csr      \
-            : "=r" (__v));      \
-  __v;              \
-})
-
-#define hal_mepc_read() csr_read(0x341)
-
-#else
 #define hal_mepc_read() hal_spr_read(RV_CSR_MEPC)
-#endif
 
 static inline unsigned int core_id() {
   int hart_id;
@@ -243,23 +224,6 @@ static inline __attribute__((always_inline)) unsigned int hal_is_fc() {
 
 
 
-#if defined(__LLVM__)
-
-static inline int hal_irq_disable()
-{
-  return 0;
-}
-
-static inline void hal_irq_restore(int state)
-{
-}
-
-static inline void hal_irq_enable()
-{
-}
-
-#else
-
 static inline int hal_irq_disable()
 {
   int irq = hal_spr_read_then_clr(0x300, 0x1<<3);
@@ -282,7 +246,6 @@ static inline void hal_irq_enable()
   hal_spr_read_then_set(0x300, 0x1<<3);
 }
 
-#endif
 
 /*
  * PERFORMANCE COUNTERS


### PR DESCRIPTION
The usage is analogous to the GCC toolchain: users must define the environmental variable "PULP_RISCV_LLVM_TOOLCHAIN".
Only one toolchain can be defined; if both env variables are present, the make system terminates with an error message.

Note that the fixes to the *.S files are general, but the related bugs are only triggered using LLVM.