### PR TITLE
Further realignment with Siracusa SDK

### DIFF
--- a/rtos/pulpos/common/include/pos/data/data.h
+++ b/rtos/pulpos/common/include/pos/data/data.h
@@ -38,7 +38,7 @@
 #ifndef LANGUAGE_ASSEMBLY
 
 // We cannot use tiny attribute if we use a generic riscv toolchain or LLVM or we there is fc specific memeory (TCDM or L2)
-#if (defined(ARCHI_HAS_FC_TCDM) || defined(ARCHI_HAS_L2_ALIAS)) && !defined(__clang__) && !defined(__RISCV_GENERIC__) && defined(CONFIG_NO_STD_RELOC)
+#if (defined(ARCHI_HAS_FC_TCDM) || defined(ARCHI_HAS_L2_ALIAS)) && !defined(__LLVM__) && !defined(__RISCV_GENERIC__) && defined(CONFIG_NO_STD_RELOC)
 #define POS_FC_TINY_ATTRIBUTE __attribute__ ((tiny))
 #else
 #define POS_FC_TINY_ATTRIBUTE

--- a/rtos/pulpos/common/kernel/crt0.S
+++ b/rtos/pulpos/common/kernel/crt0.S
@@ -20,7 +20,7 @@
 
 #include "archi/pulp.h"
 
-    .section .text_l2
+    .section .text_l2, "ax"
     .global pos_init_entry
 pos_init_entry:
 

--- a/rtos/pulpos/common/kernel/soc_event_v2_itc.S
+++ b/rtos/pulpos/common/kernel/soc_event_v2_itc.S
@@ -21,7 +21,7 @@
 #include <archi/pulp.h>
 
 
-    .section .text_l2
+    .section .text_l2, "ax"
 
     #
     # SOC event handler entry

--- a/rtos/pulpos/common/kernel/task_asm.S
+++ b/rtos/pulpos/common/kernel/task_asm.S
@@ -20,7 +20,7 @@
 
 #include <pos/data/data.h>
 
-    .section .text_l2
+    .section .text_l2, "ax"
 
     .global pos_task_push_asm
 pos_task_push_asm:

--- a/rtos/pulpos/common/kernel/time_asm.S
+++ b/rtos/pulpos/common/kernel/time_asm.S
@@ -20,7 +20,7 @@
 
 #include <pos/data/data.h>
 
-    .section .text_l2
+    .section .text_l2, "ax"
 
     .global pos_time_timer_handler_asm
 pos_time_timer_handler_asm:

--- a/rtos/pulpos/common/lib/omp/omp.c
+++ b/rtos/pulpos/common/lib/omp/omp.c
@@ -104,7 +104,7 @@ static void __rt_omp_init(int exec_main)
 
   initTeam(_this, &_this->plainTeam);
 
-#ifdef __clang__
+#ifdef __LLVM__
   _this->numThreads = 0;
 #endif
 

--- a/rtos/pulpos/common/lib/omp/ompRt.h
+++ b/rtos/pulpos/common/lib/omp/ompRt.h
@@ -59,7 +59,7 @@ typedef struct {
 typedef struct {
   //ompTask_t *taskPool;
   omp_team_t plainTeam;
-#ifdef __clang__
+#ifdef __LLVM__
   int numThreads;
 #endif
   unsigned short coreMask;

--- a/rtos/pulpos/pulp/drivers/cluster/cluster.c
+++ b/rtos/pulpos/pulp/drivers/cluster/cluster.c
@@ -115,7 +115,7 @@ int pi_cluster_open(struct pi_device *cluster_dev)
 
     pos_cluster_fc_task_lock = 0;
 
-#if __PLATFORM__ != ARCHI_PLATFORM_FPGA
+#if __PLATFORM__ != ARCHI_PLATFORM_FPGA && !defined(SKIP_PLL_INIT)
     {
         // Setup FLL
         int init_freq = pos_fll_init(POS_FLL_CL);

--- a/rtos/pulpos/pulp_archi/include/archi/gap_utils.h
+++ b/rtos/pulpos/pulp_archi/include/archi/gap_utils.h
@@ -21,7 +21,7 @@
 static inline unsigned int __attribute__ ((always_inline)) ExtInsMaskFast_archi(unsigned int Size, unsigned int Offset) { return ((((Size-1))<<5)|(Offset)); }
 static inline unsigned int __attribute__ ((always_inline)) ExtInsMaskSafe_archi(unsigned int Size, unsigned int Offset) { return ((((Size-1)&0x1F)<<5)|(Offset&0x1F)); }
 
-#if defined(__riscv__) && !defined(__clang__) && !defined(RV_ISA_RV32)
+#if defined(__riscv__) && !defined(__LLVM__) && !defined(RV_ISA_RV32)
 #define GAP_WRITE_VOL(base, offset, value) __builtin_pulp_write_base_off_v((value), (base), (offset))
 #define GAP_WRITE(base, offset, value)     __builtin_pulp_OffsetedWrite((value), (int *)(base), (offset))
 #define GAP_READ(base, offset)             __builtin_pulp_OffsetedRead((int *)(base), (offset))

--- a/rtos/pulpos/pulp_archi/include/archi/utils.h
+++ b/rtos/pulpos/pulp_archi/include/archi/utils.h
@@ -50,7 +50,7 @@
 #define archi_read(add)          (*(volatile unsigned int *)(long)(add))
 
 
-#if defined(__riscv__) && !defined(__clang__) && !defined(RV_ISA_RV32)
+#if defined(__riscv__) && !defined(__LLVM__) && !defined(RV_ISA_RV32)
 #define ARCHI_WRITE_VOL(base, offset, value) __builtin_pulp_write_base_off_v((value), (base), (offset))
 #define ARCHI_WRITE(base, offset, value)     __builtin_pulp_OffsetedWrite((value), (int *)(base), (offset))
 #define ARCHI_READ(base, offset)             __builtin_pulp_OffsetedRead((int *)(base), (offset))

--- a/rtos/pulpos/pulp_hal/include/hal/dma/mchan_v6.h
+++ b/rtos/pulpos/pulp_hal/include/hal/dma/mchan_v6.h
@@ -248,7 +248,7 @@ static inline unsigned int plp_dma_status();
 
 /// @cond IMPLEM
 
-#if defined(__riscv__) && !defined(RV_ISA_RV32) && !defined(__clang__)
+#if defined(__riscv__) && !defined(RV_ISA_RV32) && !defined(__LLVM__)
 #define DMA_WRITE(value, offset) __builtin_pulp_OffsetedWrite((value), (int *)ARCHI_DEMUX_PERIPHERALS_ADDR, ARCHI_MCHAN_DEMUX_OFFSET + (offset))
 #define DMA_READ(offset) __builtin_pulp_OffsetedRead((int *)ARCHI_DEMUX_PERIPHERALS_ADDR, ARCHI_MCHAN_DEMUX_OFFSET + (offset))
 #else

--- a/rtos/pulpos/pulp_hal/include/hal/dma/mchan_v7.h
+++ b/rtos/pulpos/pulp_hal/include/hal/dma/mchan_v7.h
@@ -258,7 +258,7 @@ static inline unsigned int plp_dma_status();
 
 /// @cond IMPLEM
 
-#if defined(__riscv__) && !defined(RV_ISA_RV32) && !defined(__clang__)
+#if defined(__riscv__) && !defined(RV_ISA_RV32) && !defined(__LLVM__)
 #define DMA_WRITE(value, offset) __builtin_pulp_OffsetedWrite((value), (int *)ARCHI_MCHAN_EXT_ADDR, (offset))
 #define DMA_READ(offset) __builtin_pulp_OffsetedRead((int *)ARCHI_MCHAN_EXT_ADDR, (offset))
 #else

--- a/rtos/pulpos/pulp_hal/include/hal/eu/eu_v3.h
+++ b/rtos/pulpos/pulp_hal/include/hal/eu/eu_v3.h
@@ -39,7 +39,7 @@
 static inline unsigned int evt_read32(unsigned int base, unsigned int offset)
 {
   unsigned int value;
-  #if !defined(__clang__) && ((defined(OR1K_VERSION) && OR1K_VERSION >= 5) || (defined(RISCV_VERSION) && RISCV_VERSION >= 4)) && !defined(CONFIG_PULP)
+  #if !defined(__LLVM__) && ((defined(OR1K_VERSION) && OR1K_VERSION >= 5) || (defined(RISCV_VERSION) && RISCV_VERSION >= 4)) && !defined(CONFIG_PULP)
   __asm__ __volatile__ ("" : : : "memory");
   value = __builtin_pulp_event_unit_read_fenced((int *)base, offset);
   __asm__ __volatile__ ("" : : : "memory");

--- a/rtos/pulpos/pulp_hal/include/hal/pulp_io.h
+++ b/rtos/pulpos/pulp_hal/include/hal/pulp_io.h
@@ -24,7 +24,7 @@
 #define pulp_write32(add, val_) (*(volatile unsigned int *)(long)(add) = val_)
 #define pulp_write(add, val_) (*(volatile unsigned int *)(long)(add) = val_)
 
-#if !defined(__clang__)
+#if !defined(__LLVM__)
 
 #define pulp_read8(add) (*(volatile unsigned char *)(long)(add))
 #define pulp_read16(add) (*(volatile unsigned short *)(long)(add))
@@ -67,7 +67,7 @@ static inline uint32_t pulp_read(uint32_t add)
 
 #endif
 
-#if defined(__riscv__) && !defined(RV_ISA_RV32) && !defined(__clang__)
+#if defined(__riscv__) && !defined(RV_ISA_RV32) && !defined(__LLVM__)
 #define IP_WRITE_VOL(base, offset, value) __builtin_pulp_write_base_off_v((value), (base), (offset))
 #define IP_WRITE(base, offset, value) __builtin_pulp_OffsetedWrite((value), (int *)(base), (offset))
 #if !defined(CONFIG_PULP)

--- a/rtos/pulpos/pulp_hal/include/hal/riscv/riscv_v4.h
+++ b/rtos/pulpos/pulp_hal/include/hal/riscv/riscv_v4.h
@@ -32,7 +32,7 @@
 
 
 
-#if defined(__OPTIMIZE__) && defined(CORE_PULP_BUILTINS)
+#if defined(__OPTIMIZE__) && defined(CORE_PULP_BUILTINS) && !defined(__LLVM__)
 
 static inline unsigned int hal_spr_read_then_clr(unsigned int reg, unsigned int val)
 {
@@ -56,6 +56,10 @@ static inline unsigned int hal_spr_read(unsigned int reg)
 
 #else
 
+#if defined(__LLVM__)
+
+#else
+ 
 #define hal_spr_read_then_clr(reg,val) \
   ({ \
     int state; \
@@ -82,11 +86,29 @@ do { \
   result; \
 })
 
+#endif
 
 #endif
 
 
+
+
+
+#if defined(__LLVM__)
+
+#define csr_read(csr)           \
+({                \
+  register unsigned int __v;       \
+  __asm__ __volatile__ ("csrr %0, " #csr      \
+            : "=r" (__v));      \
+  __v;              \
+})
+
+#define hal_mepc_read() csr_read(0x341)
+
+#else
 #define hal_mepc_read() hal_spr_read(RV_CSR_MEPC)
+#endif
 
 static inline unsigned int core_id() {
   int hart_id;
@@ -200,6 +222,23 @@ static inline __attribute__((always_inline)) unsigned int hal_is_fc() {
 
 
 
+#if defined(__LLVM__)
+
+static inline int hal_irq_disable()
+{
+  return 0;
+}
+
+static inline void hal_irq_restore(int state)
+{
+}
+
+static inline void hal_irq_enable()
+{
+}
+
+#else
+
 static inline int hal_irq_disable()
 {
   int irq = hal_spr_read_then_clr(0x300, 0x1<<3);
@@ -222,6 +261,7 @@ static inline void hal_irq_enable()
   hal_spr_read_then_set(0x300, 0x1<<3);
 }
 
+#endif
 
 /*
  * PERFORMANCE COUNTERS

--- a/rtos/pulpos/pulp_hal/include/hal/riscv/riscv_v5.h
+++ b/rtos/pulpos/pulp_hal/include/hal/riscv/riscv_v5.h
@@ -32,7 +32,7 @@
 
 
 
-#if defined(__OPTIMIZE__) && defined(CORE_PULP_BUILTINS) && !defined(__clang__)
+#if defined(__OPTIMIZE__) && defined(CORE_PULP_BUILTINS) && !defined(__LLVM__)
 
 static inline unsigned int hal_spr_read_then_clr(unsigned int reg, unsigned int val)
 {
@@ -56,7 +56,7 @@ static inline unsigned int hal_spr_read(unsigned int reg)
 
 #else
 
-#if defined(__clang__)
+#if defined(__LLVM__)
 
 #else
  
@@ -115,7 +115,7 @@ do { \
 
 
 
-#if defined(__clang__)
+#if defined(__LLVM__)
 
 #define csr_read(csr)           \
 ({                \
@@ -243,7 +243,7 @@ static inline __attribute__((always_inline)) unsigned int hal_is_fc() {
 
 
 
-#if defined(__clang__)
+#if defined(__LLVM__)
 
 static inline int hal_irq_disable()
 {

--- a/rtos/pulpos/pulp_hal/include/hal/udma/hyper/udma_hyper_v3.h
+++ b/rtos/pulpos/pulp_hal/include/hal/udma/hyper/udma_hyper_v3.h
@@ -54,7 +54,12 @@ static inline void plp_hyper_wait(unsigned char hyper_id, unsigned int tran_id){
 }
 
 static inline int plp_hyper_id_alloc(unsigned char hyper_id){
-  return plp_hyper_get_reg(UDMA_HYPER_BASE_ADDR(hyper_id) + TRANS_ID_ALLOC);
+  int tran_id = HYPER_NB_CHANNELS;
+  while(tran_id == HYPER_NB_CHANNELS)
+  {
+    tran_id = plp_hyper_get_reg(UDMA_HYPER_BASE_ADDR(hyper_id) + TRANS_ID_ALLOC);
+  }
+  return tran_id;
 }
 
 static inline void plp_hyper_set_reg(unsigned int offset, unsigned int value){


### PR DESCRIPTION
This PR includes further changes (follow-up to #149) for realignment with Siracusa SDK. Mostly these enable building with LLVM in Deeploy's CI (see related https://github.com/pulp-platform/Deeploy/pull/88 )